### PR TITLE
Dev scron fix compiler warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output)
 
 # define macro to include config.h
 add_compile_definitions(HAVE_CONFIG_H)
+add_compile_definitions(_GNU_SOURCE)
 
 # list neccessary code in freeipmi 
 FILE(GLOB_RECURSE freeipmi_sources freeipmi-1.6.9/libfreeipmi/*.c)

--- a/src/main.c
+++ b/src/main.c
@@ -338,6 +338,11 @@ static int check_process_active(const char* filename)
             continue;
         }
 
+        if ( (int)getpid() == proc_pid )
+        {
+            continue;
+        }
+
         memset(exe_path, 0, sizeof(exe_path));
         if(find_exe_by_pid(proc_pid, exe_path))
         {
@@ -345,11 +350,6 @@ static int check_process_active(const char* filename)
         }
 
         if (!strstr(exe_path, filename))
-        {
-            continue;
-        }
-
-        if ( (int)getpid() == proc_pid )
         {
             continue;
         }


### PR DESCRIPTION
Fix compiler warning of asprintf

The function asprintf() is not yet part of the C Standard. Thus, Add the
declaration of GNU_SOURCE.

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>